### PR TITLE
test: expand coverage and add CI reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,15 @@ jobs:
       - name: Type and Svelte checks
         run: pnpm check
 
-      - name: Tests
-        run: pnpm test
+      - name: Tests with coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+          if-no-files-found: error
 
       - name: Lint
         run: pnpm lint

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ package-lock.json
 .wrangler
 /.svelte-kit
 /build
+/coverage
 
 # OS
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint .",
 		"build:registry": "pnpm shadcn-svelte registry build"
@@ -31,6 +32,7 @@
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@tailwindcss/vite": "^4.2.1",
 		"@types/node": "^25.5.0",
+		"@vitest/coverage-v8": "^4.1.0",
 		"bits-ui": "^2.16.3",
 		"clsx": "^2.1.1",
 		"eslint": "^10.0.3",
@@ -50,8 +52,8 @@
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.57.1",
-		"vitest": "^4.1.0",
-		"vite": "^8.0.0"
+		"vite": "^8.0.0",
+		"vitest": "^4.1.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.0
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)))
       bits-ui:
         specifier: ^2.16.3
         version: 2.16.3(@internationalized/date@3.12.0)(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.54.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)))(svelte@5.54.0)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)))(svelte@5.54.0)
@@ -113,6 +116,27 @@ importers:
         version: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))
 
 packages:
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@dagrejs/dagre@1.1.8':
     resolution: {integrity: sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==}
@@ -842,6 +866,15 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
@@ -891,6 +924,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1253,11 +1289,18 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -1302,9 +1345,24 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1508,6 +1566,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   maplibre-gl@5.20.2:
     resolution: {integrity: sha512-0UzMWOe+GZmIUmOA99yTI1vRh15YcGnHxADVB2s+JF3etpjj2/MBCqbPEuu4BP9mLsJWJcpHH0Nzr9uuimmbuQ==}
@@ -1833,6 +1898,10 @@ packages:
   supercluster@8.0.1:
     resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   svelte-check@4.4.5:
     resolution: {integrity: sha512-1bSwIRCvvmSHrlK52fOlZmVtUZgil43jNL/2H18pRpa+eQjzGt6e3zayxhp1S7GajPFKNM/2PMCG+DZFHlG9fw==}
     engines: {node: '>= 18.0.0'}
@@ -2081,6 +2150,21 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@dagrejs/dagre@1.1.8':
     dependencies:
@@ -2701,6 +2785,20 @@ snapshots:
       '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.54.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)))(svelte@5.54.0)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))
       svelte: 5.54.0
 
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1))
+
   '@vitest/expect@4.1.0':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2758,6 +2856,12 @@ snapshots:
   aria-query@5.3.1: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   axobject-query@4.1.0: {}
 
@@ -3130,6 +3234,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  has-flag@4.0.0: {}
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -3147,6 +3253,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
 
@@ -3178,7 +3286,22 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.6.1: {}
+
+  js-tokens@10.0.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -3347,6 +3470,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   maplibre-gl@5.20.2:
     dependencies:
@@ -3633,6 +3766,10 @@ snapshots:
   supercluster@8.0.1:
     dependencies:
       kdbush: 4.0.2
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   svelte-check@4.4.5(picomatch@4.0.3)(svelte@5.54.0)(typescript@5.9.3):
     dependencies:

--- a/src/lib/blocks.test.ts
+++ b/src/lib/blocks.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { createFileTreeForRegistryItemFiles, getAllBlocks } from "./blocks";
+
+describe("getAllBlocks", () => {
+	it("returns only registry blocks with normalized defaults", () => {
+		const blocks = getAllBlocks();
+
+		expect(blocks.map((block) => block.name)).toEqual([
+			"analytics-map",
+			"logistics-network",
+			"heatmap",
+			"delivery-tracker",
+		]);
+		expect(blocks.every((block) => block.type === "registry:block")).toBe(true);
+
+		expect(blocks[0]).toMatchObject({
+			title: "Analytics Map",
+			registryDependencies: ["map", "card", "chart"],
+			categories: ["analytics", "dashboard"],
+			meta: { iframeHeight: "970px" },
+		});
+
+		expect(blocks[2]).toMatchObject({
+			title: "Heatmap",
+			files: [
+				{ path: "src/lib/registry/blocks/heatmap/Page.svelte", target: "heatmap/+page.svelte" },
+			],
+			registryDependencies: ["map", "card"],
+			categories: ["visualization", "heatmap"],
+		});
+		expect(blocks[2].meta).toBeUndefined();
+	});
+});
+
+describe("createFileTreeForRegistryItemFiles", () => {
+	it("builds a nested tree from target paths and merges shared folders", () => {
+		const tree = createFileTreeForRegistryItemFiles([
+			{
+				path: "src/lib/registry/blocks/analytics-map/Page.svelte",
+				target: "analytics/+page.svelte",
+			},
+			{ path: "src/lib/registry/blocks/analytics-map/data.ts", target: "analytics/data.ts" },
+			{ path: "src/lib/server/api.ts" },
+			{ path: "src/lib/server/routes/index.ts" },
+		]);
+
+		expect(tree).toEqual([
+			{
+				name: "analytics",
+				children: [
+					{ name: "+page.svelte", path: "analytics/+page.svelte" },
+					{ name: "data.ts", path: "analytics/data.ts" },
+				],
+			},
+			{
+				name: "src",
+				children: [
+					{
+						name: "lib",
+						children: [
+							{
+								name: "server",
+								children: [
+									{ name: "api.ts", path: "src/lib/server/api.ts" },
+									{
+										name: "routes",
+										children: [{ name: "index.ts", path: "src/lib/server/routes/index.ts" }],
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		]);
+	});
+});

--- a/src/lib/docs-navigation.test.ts
+++ b/src/lib/docs-navigation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+	docsNavigation,
+	findNeighbors,
+	fullNavItems,
+	mainNavItems,
+	siteNavigation,
+} from "./docs-navigation";
+
+describe("docs navigation", () => {
+	it("flattens documentation groups into a linear nav list", () => {
+		const itemCount = docsNavigation.reduce((count, group) => count + group.items.length, 0);
+
+		expect(fullNavItems).toHaveLength(itemCount);
+		expect(fullNavItems[0].href).toBe("/docs");
+		expect(fullNavItems.at(-1)?.href).toBe("/docs/advanced-usage");
+	});
+
+	it("includes the main site pages before the docs groups", () => {
+		expect(siteNavigation[0]).toEqual({
+			title: "Pages",
+			items: mainNavItems,
+		});
+		expect(siteNavigation.slice(1)).toEqual(docsNavigation);
+	});
+
+	it("finds adjacent docs pages after stripping query strings and hashes", () => {
+		expect(findNeighbors("/docs/installation?tab=cli#usage")).toEqual({
+			previous: fullNavItems[0],
+			next: fullNavItems[2],
+		});
+	});
+
+	it("returns null for missing neighbors at the ends of the docs list", () => {
+		expect(findNeighbors("/docs")).toEqual({
+			previous: null,
+			next: fullNavItems[1],
+		});
+		expect(findNeighbors("/docs/advanced-usage")).toEqual({
+			previous: fullNavItems.at(-2) ?? null,
+			next: null,
+		});
+	});
+});

--- a/src/lib/examples.test.ts
+++ b/src/lib/examples.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getExampleSource, getExampleSources } from "./examples";
+
+describe("examples", () => {
+	it("loads and normalizes a single example source", () => {
+		const source = getExampleSource("BasicMapExample");
+
+		expect(source).toContain("<Map");
+		expect(source).not.toContain("@/registry/map");
+	});
+
+	it("loads and normalizes multiple example sources in order", () => {
+		const examples = getExampleSources(["BasicMapExample", "MapControlsExample"]);
+
+		expect(examples).toHaveLength(2);
+		expect(examples[0]).toMatchObject({ name: "BasicMapExample" });
+		expect(examples[1]).toMatchObject({ name: "MapControlsExample" });
+		expect(examples.every((example) => example.code.includes("@/registry/map"))).toBe(false);
+	});
+
+	it("throws for a missing example file", () => {
+		expect(() => getExampleSource("MissingExample")).toThrow(
+			"Example file not found: MissingExample"
+		);
+		expect(() => getExampleSources(["BasicMapExample", "MissingExample"])).toThrow(
+			"Example file not found: MissingExample"
+		);
+	});
+});

--- a/src/lib/get-block-file-source.test.ts
+++ b/src/lib/get-block-file-source.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getBlockFileSource } from "./get-block-file-source";
+
+describe("getBlockFileSource", () => {
+	it("rewrites registry map imports to installed component imports", () => {
+		const source = getBlockFileSource("src/lib/registry/blocks/analytics-map/Page.svelte");
+
+		expect(source).toContain('import Map from "$lib/components/map/Map.svelte";');
+		expect(source).not.toContain("$lib/registry/blocks/map");
+	});
+
+	it("leaves unrelated imports untouched", () => {
+		const source = getBlockFileSource("src/lib/registry/blocks/map/index.ts");
+
+		expect(source).toContain('export { default as Map } from "./Map.svelte";');
+		expect(source).not.toContain("$lib/components/map");
+	});
+
+	it("surfaces filesystem errors for missing files", () => {
+		expect(() => getBlockFileSource("src/lib/registry/blocks/missing/File.svelte")).toThrow(
+			"ENOENT"
+		);
+	});
+});

--- a/src/lib/highlight.test.ts
+++ b/src/lib/highlight.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const codeToHtml = vi.fn();
+const createHighlighter = vi.fn(async () => ({ codeToHtml }));
+
+vi.mock("shiki", () => ({
+	createHighlighter,
+}));
+
+describe("highlightCode", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("creates a highlighter once and uses the default svelte language", async () => {
+		vi.resetModules();
+		codeToHtml.mockReturnValue("<pre>first</pre>");
+
+		const { highlightCode } = await import("./highlight");
+
+		await expect(highlightCode("<script />")).resolves.toBe("<pre>first</pre>");
+		expect(createHighlighter).toHaveBeenCalledTimes(1);
+		expect(createHighlighter).toHaveBeenCalledWith({
+			themes: ["github-dark", "github-light"],
+			langs: ["ts", "tsx", "js", "jsx", "json", "bash", "css", "html", "md", "svelte"],
+		});
+		expect(codeToHtml).toHaveBeenCalledWith("<script />", {
+			lang: "svelte",
+			themes: {
+				light: "github-light",
+				dark: "github-dark",
+			},
+			defaultColor: false,
+		});
+	});
+
+	it("reuses the cached highlighter and forwards explicit languages", async () => {
+		vi.resetModules();
+		codeToHtml.mockResolvedValue("<pre>shared</pre>");
+
+		const { highlightCode } = await import("./highlight");
+
+		await highlightCode("const value = 1;", "ts");
+		await highlightCode("console.log(value)", "js");
+
+		expect(createHighlighter).toHaveBeenCalledTimes(1);
+		expect(codeToHtml).toHaveBeenNthCalledWith(1, "const value = 1;", {
+			lang: "ts",
+			themes: {
+				light: "github-light",
+				dark: "github-dark",
+			},
+			defaultColor: false,
+		});
+		expect(codeToHtml).toHaveBeenNthCalledWith(2, "console.log(value)", {
+			lang: "js",
+			themes: {
+				light: "github-light",
+				dark: "github-dark",
+			},
+			defaultColor: false,
+		});
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import tailwindcss from "@tailwindcss/vite";
 import { sveltekit } from "@sveltejs/kit/vite";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
+	test: {
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "lcov"],
+		},
+	},
 });


### PR DESCRIPTION
## Summary
- expand unit coverage for docs loaders, registry helpers, navigation helpers, and highlighting logic
- enable Vitest V8 coverage reporting locally and in CI, and upload the coverage artifact from GitHub Actions
- keep generated coverage output out of the worktree with a .gitignore entry

## Test Plan
- [x] pnpm check
- [x] pnpm test:coverage
- [x] pnpm lint