### PR TITLE
Fix #17: register missing files in registry.json

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -62,6 +62,11 @@
 					"target": "map/MapClusterLayer.svelte"
 				},
 				{
+					"path": "src/lib/registry/blocks/map/MapArc.svelte",
+					"type": "registry:ui",
+					"target": "map/MapArc.svelte"
+				},
+				{
 					"path": "src/lib/registry/blocks/map/index.ts",
 					"type": "registry:ui",
 					"target": "map/index.ts"

--- a/registry.json
+++ b/registry.json
@@ -67,6 +67,11 @@
 					"target": "map/MapArc.svelte"
 				},
 				{
+					"path": "src/lib/registry/blocks/map/theme.ts",
+					"type": "registry:ui",
+					"target": "map/theme.ts"
+				},
+				{
 					"path": "src/lib/registry/blocks/map/index.ts",
 					"type": "registry:ui",
 					"target": "map/index.ts"
@@ -171,6 +176,11 @@
 					"path": "src/lib/registry/blocks/heatmap/Page.svelte",
 					"type": "registry:page",
 					"target": "heatmap/+page.svelte"
+				},
+				{
+					"path": "src/lib/registry/blocks/heatmap/GlobeHeatmapLayers.svelte",
+					"type": "registry:component",
+					"target": "heatmap/GlobeHeatmapLayers.svelte"
 				}
 			],
 			"categories": ["visualization", "heatmap"]

--- a/src/lib/blocks.test.ts
+++ b/src/lib/blocks.test.ts
@@ -26,6 +26,10 @@ describe("getAllBlocks", () => {
 			title: "Heatmap",
 			files: [
 				{ path: "src/lib/registry/blocks/heatmap/Page.svelte", target: "heatmap/+page.svelte" },
+				{
+					path: "src/lib/registry/blocks/heatmap/GlobeHeatmapLayers.svelte",
+					target: "heatmap/GlobeHeatmapLayers.svelte",
+				},
 			],
 			categories: ["visualization", "heatmap"],
 		});

--- a/src/lib/registry.test.ts
+++ b/src/lib/registry.test.ts
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import registry from "../../registry.json";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+type RegistryFile = { path: string; type: string; target: string };
+type RegistryItem = {
+	name: string;
+	type: string;
+	title: string;
+	description: string;
+	files: RegistryFile[];
+	registryDependencies?: string[];
+};
+
+const items = registry.items as RegistryItem[];
+
+describe("registry.json", () => {
+	it("has the expected top-level shape", () => {
+		expect(registry.name).toBeTypeOf("string");
+		expect(registry.homepage).toBeTypeOf("string");
+		expect(Array.isArray(registry.items)).toBe(true);
+		expect(registry.items.length).toBeGreaterThan(0);
+	});
+
+	it("has unique item names", () => {
+		const names = items.map((item) => item.name);
+		expect(new Set(names).size).toBe(names.length);
+	});
+
+	describe.each(items)("item: $name", (item) => {
+		it("has the required metadata fields", () => {
+			expect(item.name, "name").toBeTruthy();
+			expect(item.type, "type").toMatch(/^registry:/);
+			expect(item.title, "title").toBeTruthy();
+			expect(item.description, "description").toBeTruthy();
+			expect(item.files.length, "files").toBeGreaterThan(0);
+		});
+
+		it("has well-formed file entries", () => {
+			for (const file of item.files) {
+				expect(file.path, "path").toBeTypeOf("string");
+				expect(file.type, "type").toMatch(/^registry:/);
+				expect(file.target, "target").toBeTypeOf("string");
+			}
+		});
+
+		it("has unique file paths and targets", () => {
+			const paths = item.files.map((file) => file.path);
+			const targets = item.files.map((file) => file.target);
+			expect(new Set(paths).size, "duplicate path").toBe(paths.length);
+			expect(new Set(targets).size, "duplicate target").toBe(targets.length);
+		});
+
+		it("references files that exist on disk", () => {
+			for (const file of item.files) {
+				expect(existsSync(path.join(repoRoot, file.path)), `missing on disk: ${file.path}`).toBe(
+					true
+				);
+			}
+		});
+
+		// Generalizes issue #17: any sibling file a registered file imports must
+		// itself be registered, otherwise a fresh install resolves a dangling import.
+		it("registers every local file its sources import", () => {
+			const registeredAbsPaths = new Set(
+				item.files.map((file) => path.resolve(repoRoot, file.path))
+			);
+
+			for (const file of item.files) {
+				const absPath = path.join(repoRoot, file.path);
+				if (!existsSync(absPath)) continue;
+
+				const source = readFileSync(absPath, "utf8");
+				const fileDir = path.dirname(absPath);
+
+				for (const spec of relativeImports(source)) {
+					const resolved = resolveLocalImport(fileDir, spec);
+					if (!resolved) continue; // import target not found on disk -> not a registry concern here
+
+					expect(
+						registeredAbsPaths.has(resolved),
+						`${file.path} imports "${spec}" but ${path.relative(repoRoot, resolved)} is not registered in registry.json`
+					).toBe(true);
+				}
+			}
+		});
+	});
+});
+
+/** Collect every relative specifier used in `import ... from "./x"` / `export ... from "./x"`. */
+function relativeImports(source: string): string[] {
+	const specs = new Set<string>();
+	const re = /\bfrom\s+["'](\.\.?\/[^"']+)["']/g;
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(source)) !== null) {
+		specs.add(match[1]);
+	}
+	return [...specs];
+}
+
+/** Resolve a relative import to an existing on-disk file, mirroring TS/Svelte resolution. */
+function resolveLocalImport(fromDir: string, spec: string): string | null {
+	const base = path.resolve(fromDir, spec);
+	const candidates: string[] = [];
+
+	if (spec.endsWith(".svelte") || spec.endsWith(".ts")) {
+		candidates.push(base);
+	} else if (spec.endsWith(".js")) {
+		// TS convention: import "./data.js" resolves to data.ts
+		candidates.push(base.replace(/\.js$/, ".ts"), base);
+	} else {
+		candidates.push(`${base}.ts`, `${base}.svelte`, `${base}.js`, path.join(base, "index.ts"));
+	}
+
+	return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}


### PR DESCRIPTION
## Summary

Fixes #17. On a fresh install, the `map` component failed with `failed to resolve import "./MapArc.svelte"` because `MapArc.svelte` was exported from `index.ts` but never registered in `registry.json`, so it was missing from the generated `/r/map.json`.

`registry.json` is the hand-authored source of truth; `pnpm build:registry` generates `static/r/*.json` from it at deploy time. The file simply needed to be registered.

## Changes

- Register `map/MapArc.svelte` in `registry.json` (the direct cause of #17).
- Register two more files that were imported by registered sources but missing from the manifest — same latent fresh-install bug:
  - `map/theme.ts` (imported by `Map.svelte`)
  - `heatmap/GlobeHeatmapLayers.svelte` (imported by the heatmap `Page.svelte`)
- Add `src/lib/registry.test.ts` validating the whole `registry.json`: shape/metadata, unique names/paths/targets, every registered file exists on disk, and — generalizing #17 — every local file imported by a registered source is itself registered.

## Verification

- `pnpm vitest run src/lib/registry.test.ts` → 27 passing.
- `pnpm build:registry` regenerates `static/r/map.json` and `static/r/heatmap.json` with the previously missing files present.