### PR TITLE
Port latest upstream mapcn changes

### DIFF
--- a/src/lib/components/CommandSearch.svelte
+++ b/src/lib/components/CommandSearch.svelte
@@ -38,7 +38,7 @@
 	onclick={() => (open = true)}
 	aria-label="Jump to pages, components, and docs"
 	class={cn(
-		"group dark:border-border/60 border-border/80 text-muted-foreground hidden w-[200px] items-center text-sm md:flex",
+		"group bg-muted dark:bg-muted/50 text-muted-foreground hover:bg-muted/60 dark:hover:bg-muted/60 hover:text-foreground hidden w-[200px] items-center text-sm md:flex",
 		className
 	)}
 >

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -28,10 +28,10 @@
 
 <footer class={cn("mt-30 border-t", className)}>
 	<div class="container py-12 md:py-16">
-		<div class="grid grid-cols-2 gap-8 md:grid-cols-4">
-			<div class="col-span-2 md:col-span-1">
+		<div class="grid grid-cols-2 gap-8 md:grid-cols-5">
+			<div class="col-span-2 md:col-span-2">
 				<Logo class="w-fit" />
-				<p class="text-muted-foreground mt-3 max-w-xs text-sm leading-relaxed">
+				<p class="text-muted-foreground mt-2 max-w-xs text-sm leading-relaxed">
 					Free & open-source, ready-to-use, customizable map components for Svelte.
 				</p>
 				<p class="text-muted-foreground mt-3 text-sm">

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -33,7 +33,7 @@
 		</h1>
 
 		<p
-			class="text-muted-foreground animate-fade-up animate-stagger max-w-2xl sm:text-lg sm:leading-relaxed md:text-xl md:leading-relaxed"
+			class="text-foreground/80 animate-fade-up animate-stagger max-w-2xl sm:text-lg sm:leading-relaxed md:text-xl md:leading-relaxed"
 			style="--stagger: 2"
 		>
 			Ready to use, customizable map components for Svelte.
@@ -66,8 +66,8 @@
 			class="animate-fade-up animate-stagger mt-3 flex flex-wrap items-center justify-center gap-3"
 			style="--stagger: 4"
 		>
-			<Button size="lg" href="/docs">Get Started</Button>
-			<Button size="lg" variant="outline" href="/docs/basic-map">View Components</Button>
+			<Button href="/docs">Get Started</Button>
+			<Button variant="outline" href="/docs/basic-map">View Components</Button>
 		</div>
 	</div>
 </div>

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -15,13 +15,13 @@
 	<a
 		href="/"
 		{onclick}
-		class={cn("flex h-8 items-center gap-1.5 text-lg font-semibold", className)}
+		class={cn("flex h-8 items-center gap-1.5 text-[17px] font-semibold", className)}
 	>
 		<MapPin class="text-svelte size-4" />
 		mapcn-svelte
 	</a>
 {:else}
-	<div class={cn("flex items-center gap-1.5 text-lg font-semibold", className)}>
+	<div class={cn("flex items-center gap-1.5 text-[17px] font-semibold", className)}>
 		<MapPin class="text-svelte size-4" />
 		mapcn-svelte
 	</div>

--- a/src/lib/components/docs/DocsLayout.svelte
+++ b/src/lib/components/docs/DocsLayout.svelte
@@ -61,7 +61,7 @@
 </script>
 
 <div class="flex gap-8">
-	<div class="mx-auto flex max-w-[52rem] min-w-0 flex-1 flex-col pt-10 pb-20 lg:px-4">
+	<div class="mx-auto flex max-w-[50rem] min-w-0 flex-1 flex-col pt-10 pb-20 lg:px-4">
 		<div class="space-y-3">
 			<h1 class="text-foreground text-3xl font-semibold tracking-tight">{title}</h1>
 			<p class="text-muted-foreground leading-relaxed">{description}</p>

--- a/src/lib/components/docs/preview/examples/ArcExample.svelte
+++ b/src/lib/components/docs/preview/examples/ArcExample.svelte
@@ -14,11 +14,21 @@
 		{ name: "Sydney", lng: 151.2093, lat: -33.8688 },
 	];
 
-	const arcs = destinations.map((dest) => ({
-		id: dest.name,
-		from: [hub.lng, hub.lat] as [number, number],
-		to: [dest.lng, dest.lat] as [number, number],
-	}));
+	const sanFrancisco = { name: "San Francisco", lng: -122.4194, lat: 37.7749 };
+	const tokyo = destinations.find((dest) => dest.name === "Tokyo")!;
+
+	const arcs = [
+		...destinations.map((dest) => ({
+			id: dest.name,
+			from: [hub.lng, hub.lat] as [number, number],
+			to: [dest.lng, dest.lat] as [number, number],
+		})),
+		{
+			id: "tokyo-sf",
+			from: [tokyo.lng, tokyo.lat] as [number, number],
+			to: [sanFrancisco.lng, sanFrancisco.lat] as [number, number],
+		},
+	];
 </script>
 
 <div class="h-[420px] w-full">
@@ -44,7 +54,7 @@
 			</MarkerContent>
 		</MapMarker>
 
-		{#each destinations as dest (dest.name)}
+		{#each [...destinations, sanFrancisco] as dest (dest.name)}
 			<MapMarker longitude={dest.lng} latitude={dest.lat}>
 				<MarkerContent>
 					<div class="size-2 rounded-full border-2 border-white bg-emerald-500 shadow"></div>

--- a/src/lib/registry/blocks/map/MapArc.svelte
+++ b/src/lib/registry/blocks/map/MapArc.svelte
@@ -27,7 +27,10 @@
 		id?: string;
 		/**
 		 * How far each arc bows away from a straight line. `0` renders straight lines;
-		 * higher values bend further. Negative values bend to the opposite side. (default: 0.2)
+		 * higher values bend further. Negative values bend to the opposite side. Arcs are
+		 * computed as a quadratic Bezier in lng/lat space; the destination longitude is
+		 * unwrapped relative to the origin so arcs cross the antimeridian via the shorter
+		 * great-circle direction. (default: 0.2)
 		 */
 		curvature?: number;
 		/** Number of samples used to render each curve. Higher = smoother. (default: 64) */
@@ -95,12 +98,15 @@
 		samples: number
 	): [number, number][] {
 		const [x0, y0] = from;
-		const [x2, y2] = to;
+		const [xTo, y2] = to;
+		// Unwrap destination longitude so antimeridian arcs use the short path.
+		const rawDx = xTo - x0;
+		const x2 = rawDx > 180 ? xTo - 360 : rawDx < -180 ? xTo + 360 : xTo;
 		const dx = x2 - x0;
 		const dy = y2 - y0;
 		const distance = Math.hypot(dx, dy);
 
-		if (distance === 0 || curvature === 0) return [from, to];
+		if (distance === 0 || curvature === 0) return [from, [x2, y2]];
 
 		const mx = (x0 + x2) / 2;
 		const my = (y0 + y2) / 2;

--- a/src/routes/blocks/+page.svelte
+++ b/src/routes/blocks/+page.svelte
@@ -43,7 +43,7 @@
 			</span>
 		</h1>
 		<p
-			class="text-muted-foreground animate-fade-up animate-stagger max-w-2xl leading-relaxed sm:text-lg md:text-xl"
+			class="text-foreground/80 animate-fade-up animate-stagger max-w-2xl leading-relaxed sm:text-lg md:text-xl"
 			style="--stagger: 2"
 		>
 			Pre-built, ready-to-use map blocks. Browse, preview, and copy them into your app with one


### PR DESCRIPTION
## Summary
- port upstream mapcn antimeridian arc fix from e98b0a7 / PR #64
- add the Tokyo to San Francisco arc example to cover the antimeridian case
- port matching upstream site spacing and visual polish from 582697b

## Validation
- pnpm lint
- pnpm check
- pnpm test
- pnpm build

Note: pnpm build completed successfully, but logged a prerender-time fetch failure for router.project-osrm.org due DNS/network access.