### PR TITLE
Fix map registry install files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 	},
 	"dependencies": {
 		"@vercel/analytics": "^2.0.1",
+		"d3-shape": "^3.2.0",
 		"maplibre-gl": "^5.23.0",
 		"shiki": "^4.0.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@6.0.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))
+      d3-shape:
+        specifier: ^3.2.0
+        version: 3.2.0
       maplibre-gl:
         specifier: ^5.23.0
         version: 5.23.0

--- a/registry.json
+++ b/registry.json
@@ -2,6 +2,9 @@
 	"$schema": "../sites/docs/static/schema/registry.json",
 	"name": "mapcn-svelte",
 	"homepage": "https://github.com/MariusLang/mapcn-svelte",
+	"aliases": {
+		"components": "$lib/components"
+	},
 	"items": [
 		{
 			"name": "map",

--- a/registry.json
+++ b/registry.json
@@ -72,6 +72,11 @@
 					"target": "map/theme.ts"
 				},
 				{
+					"path": "src/lib/registry/blocks/map/use-map.svelte.ts",
+					"type": "registry:ui",
+					"target": "map/use-map.svelte.ts"
+				},
+				{
 					"path": "src/lib/registry/blocks/map/index.ts",
 					"type": "registry:ui",
 					"target": "map/index.ts"

--- a/src/lib/components/docs/preview/examples/ClusterExample.svelte
+++ b/src/lib/components/docs/preview/examples/ClusterExample.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import { Map } from "$lib/components/ui/map";
-	import MapControls from "$lib/registry/blocks/map/MapControls.svelte";
-	import MapClusterLayer from "$lib/registry/blocks/map/MapClusterLayer.svelte";
-	import MapPopup from "$lib/registry/blocks/map/MapPopup.svelte";
+	import { Map, MapClusterLayer, MapControls, MapPopup } from "$lib/components/ui/map";
 
 	interface EarthquakeProperties {
 		mag: number;

--- a/src/lib/get-block-file-source.test.ts
+++ b/src/lib/get-block-file-source.test.ts
@@ -5,7 +5,7 @@ describe("getBlockFileSource", () => {
 	it("rewrites registry map imports to installed component imports", () => {
 		const source = getBlockFileSource("src/lib/registry/blocks/analytics-map/Page.svelte");
 
-		expect(source).toContain('import Map from "$lib/components/map/Map.svelte";');
+		expect(source).toContain('from "$lib/components/ui/map";');
 		expect(source).not.toContain("$lib/registry/blocks/map");
 	});
 
@@ -13,7 +13,7 @@ describe("getBlockFileSource", () => {
 		const source = getBlockFileSource("src/lib/registry/blocks/map/index.ts");
 
 		expect(source).toContain('export { default as Map } from "./Map.svelte";');
-		expect(source).not.toContain("$lib/components/map");
+		expect(source).not.toContain("$lib/components/ui/map");
 	});
 
 	it("surfaces filesystem errors for missing files", () => {

--- a/src/lib/get-block-file-source.ts
+++ b/src/lib/get-block-file-source.ts
@@ -7,5 +7,5 @@ export function getBlockFileSource(registryPath: string): string {
 	const filePath = join(SRC_DIR, registryPath);
 	const source = readFileSync(filePath, "utf-8");
 	// Rewrite import paths so installed files reference the correct location
-	return source.replace(/\$lib\/registry\/blocks\/map/g, "$lib/components/map");
+	return source.replace(/\$lib\/registry\/blocks\/map/g, "$lib/components/ui/map");
 }

--- a/src/lib/registry.test.ts
+++ b/src/lib/registry.test.ts
@@ -119,9 +119,10 @@ function resolveLocalImport(fromDir: string, spec: string): string | null {
 	if (spec.startsWith("$lib/registry/ui/")) return null;
 	if (spec === "$lib/utils.js" || spec === "$lib/utils") return null;
 
+	const registrySpec = spec.replace("$lib/components/ui/map", "$lib/registry/blocks/map");
 	const base = spec.startsWith("$lib/")
-		? path.resolve(repoRoot, "src/lib", spec.slice("$lib/".length))
-		: path.resolve(fromDir, spec);
+		? path.resolve(repoRoot, "src/lib", registrySpec.slice("$lib/".length))
+		: path.resolve(fromDir, registrySpec);
 	const candidates: string[] = [];
 
 	if (spec.endsWith(".svelte") || spec.endsWith(".ts")) {

--- a/src/lib/registry.test.ts
+++ b/src/lib/registry.test.ts
@@ -66,9 +66,7 @@ describe("registry.json", () => {
 		// Generalizes issue #17: any sibling file a registered file imports must
 		// itself be registered, otherwise a fresh install resolves a dangling import.
 		it("registers every local file its sources import", () => {
-			const registeredAbsPaths = new Set(
-				item.files.map((file) => path.resolve(repoRoot, file.path))
-			);
+			const registeredAbsPaths = collectRegisteredPaths(item);
 
 			for (const file of item.files) {
 				const absPath = path.join(repoRoot, file.path);
@@ -77,7 +75,7 @@ describe("registry.json", () => {
 				const source = readFileSync(absPath, "utf8");
 				const fileDir = path.dirname(absPath);
 
-				for (const spec of relativeImports(source)) {
+				for (const spec of importSpecifiers(source)) {
 					const resolved = resolveLocalImport(fileDir, spec);
 					if (!resolved) continue; // import target not found on disk -> not a registry concern here
 
@@ -91,10 +89,10 @@ describe("registry.json", () => {
 	});
 });
 
-/** Collect every relative specifier used in `import ... from "./x"` / `export ... from "./x"`. */
-function relativeImports(source: string): string[] {
+/** Collect every import/export specifier used in `from "./x"` / `from "$lib/x"`. */
+function importSpecifiers(source: string): string[] {
 	const specs = new Set<string>();
-	const re = /\bfrom\s+["'](\.\.?\/[^"']+)["']/g;
+	const re = /\bfrom\s+["']((?:\.\.?\/|\$lib\/)[^"']+)["']/g;
 	let match: RegExpExecArray | null;
 	while ((match = re.exec(source)) !== null) {
 		specs.add(match[1]);
@@ -102,9 +100,28 @@ function relativeImports(source: string): string[] {
 	return [...specs];
 }
 
+function collectRegisteredPaths(item: RegistryItem): Set<string> {
+	const paths = new Set(item.files.map((file) => path.resolve(repoRoot, file.path)));
+
+	for (const dependency of item.registryDependencies ?? []) {
+		if (!dependency.endsWith("/r/map.json")) continue;
+		const mapItem = items.find((entry) => entry.name === "map");
+		for (const file of mapItem?.files ?? []) {
+			paths.add(path.resolve(repoRoot, file.path));
+		}
+	}
+
+	return paths;
+}
+
 /** Resolve a relative import to an existing on-disk file, mirroring TS/Svelte resolution. */
 function resolveLocalImport(fromDir: string, spec: string): string | null {
-	const base = path.resolve(fromDir, spec);
+	if (spec.startsWith("$lib/registry/ui/")) return null;
+	if (spec === "$lib/utils.js" || spec === "$lib/utils") return null;
+
+	const base = spec.startsWith("$lib/")
+		? path.resolve(repoRoot, "src/lib", spec.slice("$lib/".length))
+		: path.resolve(fromDir, spec);
 	const candidates: string[] = [];
 
 	if (spec.endsWith(".svelte") || spec.endsWith(".ts")) {

--- a/src/lib/registry/blocks/analytics-map/Page.svelte
+++ b/src/lib/registry/blocks/analytics-map/Page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-	import Map from "$lib/registry/blocks/map/Map.svelte";
-	import MapControls from "$lib/registry/blocks/map/MapControls.svelte";
-	import MapMarker from "$lib/registry/blocks/map/MapMarker.svelte";
-	import MarkerContent from "$lib/registry/blocks/map/MarkerContent.svelte";
-	import MarkerTooltip from "$lib/registry/blocks/map/MarkerTooltip.svelte";
+	import {
+		Map,
+		MapControls,
+		MapMarker,
+		MarkerContent,
+		MarkerTooltip,
+	} from "$lib/components/ui/map";
 	import OverviewCard from "./OverviewCard.svelte";
 	import BreakdownCard from "./BreakdownCard.svelte";
 	import {

--- a/src/lib/registry/blocks/delivery-tracker/Page.svelte
+++ b/src/lib/registry/blocks/delivery-tracker/Page.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-	import Map from "$lib/registry/blocks/map/Map.svelte";
-	import MapMarker from "$lib/registry/blocks/map/MapMarker.svelte";
-	import MapRoute from "$lib/registry/blocks/map/MapRoute.svelte";
-	import MarkerContent from "$lib/registry/blocks/map/MarkerContent.svelte";
-	import MarkerTooltip from "$lib/registry/blocks/map/MarkerTooltip.svelte";
+	import { Map, MapMarker, MapRoute, MarkerContent, MarkerTooltip } from "$lib/components/ui/map";
 	import * as Badge from "$lib/registry/ui/badge/index.js";
 	import * as Button from "$lib/registry/ui/button/index.js";
 	import * as Card from "$lib/registry/ui/card/index.js";

--- a/src/lib/registry/blocks/heatmap/GlobeHeatmapLayers.svelte
+++ b/src/lib/registry/blocks/heatmap/GlobeHeatmapLayers.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { useMap } from "$lib/registry/blocks/map/use-map.svelte.js";
+	import { useMap } from "$lib/components/ui/map";
 
 	const EARTHQUAKE_GEOJSON_URL =
 		"https://maplibre.org/maplibre-gl-js/docs/assets/earthquakes.geojson";

--- a/src/lib/registry/blocks/heatmap/GlobeHeatmapLayers.svelte
+++ b/src/lib/registry/blocks/heatmap/GlobeHeatmapLayers.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { useMap } from "$lib/hooks/use-map.svelte.js";
+	import { useMap } from "$lib/registry/blocks/map/use-map.svelte.js";
 
 	const EARTHQUAKE_GEOJSON_URL =
 		"https://maplibre.org/maplibre-gl-js/docs/assets/earthquakes.geojson";

--- a/src/lib/registry/blocks/heatmap/Page.svelte
+++ b/src/lib/registry/blocks/heatmap/Page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Map from "$lib/registry/blocks/map/Map.svelte";
+	import { Map } from "$lib/components/ui/map";
 	import * as Card from "$lib/registry/ui/card/index.js";
 	import GlobeHeatmapLayers from "./GlobeHeatmapLayers.svelte";
 

--- a/src/lib/registry/blocks/logistics-network/MapArcs.svelte
+++ b/src/lib/registry/blocks/logistics-network/MapArcs.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { useMap } from "$lib/hooks/use-map.svelte.js";
+	import { useMap } from "$lib/registry/blocks/map/use-map.svelte.js";
 	import type MapLibreGL from "maplibre-gl";
 	import { hubs, modeConfig, statusConfig, type Route } from "./data.js";
 

--- a/src/lib/registry/blocks/logistics-network/MapArcs.svelte
+++ b/src/lib/registry/blocks/logistics-network/MapArcs.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { useMap } from "$lib/registry/blocks/map/use-map.svelte.js";
+	import { useMap } from "$lib/components/ui/map";
 	import type MapLibreGL from "maplibre-gl";
 	import { hubs, modeConfig, statusConfig, type Route } from "./data.js";
 

--- a/src/lib/registry/blocks/logistics-network/NetworkMap.svelte
+++ b/src/lib/registry/blocks/logistics-network/NetworkMap.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-	import Map from "$lib/registry/blocks/map/Map.svelte";
-	import MapArc from "$lib/registry/blocks/map/MapArc.svelte";
-	import MapControls from "$lib/registry/blocks/map/MapControls.svelte";
-	import MapMarker from "$lib/registry/blocks/map/MapMarker.svelte";
-	import MarkerContent from "$lib/registry/blocks/map/MarkerContent.svelte";
-	import MarkerTooltip from "$lib/registry/blocks/map/MarkerTooltip.svelte";
+	import {
+		Map,
+		MapArc,
+		MapControls,
+		MapMarker,
+		MarkerContent,
+		MarkerTooltip,
+	} from "$lib/components/ui/map";
 	import { SidebarTrigger } from "$lib/registry/ui/sidebar/index.js";
 	import { Separator } from "$lib/registry/ui/separator/index.js";
 	import { modeConfig, regionLabels, statusConfig, type Hub, type Route } from "./data.js";

--- a/src/lib/registry/blocks/map/Map.svelte
+++ b/src/lib/registry/blocks/map/Map.svelte
@@ -3,7 +3,6 @@
 	import MapLibreGL from "maplibre-gl";
 	import "maplibre-gl/dist/maplibre-gl.css";
 	import { browser } from "$app/environment";
-	import { theme } from "$lib/theme";
 	import { resolveMapTheme } from "./theme";
 
 	// Check document class for theme (works with next-themes, etc.)
@@ -139,16 +138,6 @@
 
 	onMount(() => {
 		isMounted = true;
-
-		// Subscribe to theme store for instant updates
-		const themeUnsubscribe = theme.subscribe((value) => {
-			tailwindTheme = value;
-		});
-
-		// Clean up theme subscription
-		onDestroy(() => {
-			themeUnsubscribe();
-		});
 
 		if (browser) {
 			// Also watch for document class changes (e.g., external theme togglers)

--- a/src/lib/registry/blocks/map/MapArc.svelte
+++ b/src/lib/registry/blocks/map/MapArc.svelte
@@ -53,7 +53,7 @@
 </script>
 
 <script lang="ts" generics="T extends MapArcDatum = MapArcDatum">
-	import { useMap } from "$lib/hooks/use-map.svelte.js";
+	import { useMap } from "./use-map.svelte.js";
 
 	let {
 		data,

--- a/src/lib/registry/blocks/map/index.ts
+++ b/src/lib/registry/blocks/map/index.ts
@@ -11,3 +11,4 @@ export { default as MapRoute } from "./MapRoute.svelte";
 export { default as MapClusterLayer } from "./MapClusterLayer.svelte";
 export { default as MapArc } from "./MapArc.svelte";
 export type { MapArcDatum, MapArcEvent, MapArcProps } from "./MapArc.svelte";
+export { useMap } from "./use-map.svelte.js";

--- a/src/lib/registry/blocks/map/use-map.svelte.ts
+++ b/src/lib/registry/blocks/map/use-map.svelte.ts
@@ -1,0 +1,28 @@
+import { getContext } from "svelte";
+import MapLibreGL from "maplibre-gl";
+
+type MapContext = {
+	getMap: () => MapLibreGL.Map | null;
+	isLoaded: () => boolean;
+	isStyleReady: () => boolean;
+};
+
+export function useMap() {
+	const mapCtx = getContext<MapContext>("map");
+
+	const map = $derived.by(() => mapCtx?.getMap() ?? null);
+	const isLoaded = $derived.by(() => mapCtx?.isLoaded() ?? false);
+	const isStyleReady = $derived.by(() => mapCtx?.isStyleReady() ?? false);
+
+	return {
+		get map() {
+			return map;
+		},
+		get isLoaded() {
+			return isLoaded;
+		},
+		get isStyleReady() {
+			return isStyleReady;
+		},
+	};
+}


### PR DESCRIPTION
## Summary

- make the map registry item self-contained by moving `useMap` into the registry map files and registering it in `map.json`
- remove the docs app `$lib/theme` store dependency from the installable `Map.svelte`
- update block registry imports so dependent block installs resolve map APIs through the installed `$lib/components/ui/map` entrypoint
- add a registry regression test for dangling local `$lib` imports and add the missing `d3-shape` runtime dependency needed by the existing analytics block

Fixes #19.

## Validation

- `pnpm dlx pnpm@10.33.2 test -- src/lib/registry.test.ts src/lib/get-block-file-source.test.ts src/lib/registry/blocks/map/theme.test.ts`
- `pnpm dlx pnpm@10.33.2 lint`
- `pnpm dlx pnpm@10.33.2 check`
- `pnpm dlx pnpm@10.33.2 build`
- simulated `shadcn-svelte add` against a local post-deploy registry copy and confirmed installed files no longer contain `$lib/theme`, `$lib/hooks/use-map`, or `$lib/registry/blocks/map`
