### PR TITLE
Port mapcn updates

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -182,6 +182,30 @@
 			}
 		},
 		{
+			"name": "analytics-card",
+			"type": "registry:block",
+			"title": "Analytics Card",
+			"description": "Compact analytics card with a headline metric over a world map.",
+			"dependencies": ["maplibre-gl"],
+			"registryDependencies": ["https://mapcn-svelte.dev/r/map.json", "button"],
+			"files": [
+				{
+					"path": "src/lib/registry/blocks/analytics-card/Page.svelte",
+					"type": "registry:page",
+					"target": "analytics-card/+page.svelte"
+				},
+				{
+					"path": "src/lib/registry/blocks/analytics-card/data.ts",
+					"type": "registry:component",
+					"target": "analytics-card/data.ts"
+				}
+			],
+			"categories": ["analytics", "card"],
+			"meta": {
+				"iframeHeight": "600px"
+			}
+		},
+		{
 			"name": "choropleth",
 			"type": "registry:block",
 			"title": "Choropleth",

--- a/registry.json
+++ b/registry.json
@@ -187,7 +187,7 @@
 			"title": "Analytics Card",
 			"description": "Compact analytics card with a headline metric over a world map.",
 			"dependencies": ["maplibre-gl"],
-			"registryDependencies": ["https://mapcn-svelte.dev/r/map.json", "button"],
+			"registryDependencies": ["https://mapcn-svelte.dev/r/map.json"],
 			"files": [
 				{
 					"path": "src/lib/registry/blocks/analytics-card/Page.svelte",

--- a/src/app.css
+++ b/src/app.css
@@ -165,7 +165,7 @@
 @keyframes fade-up {
 	from {
 		opacity: 0;
-		transform: translateY(12px);
+		transform: translateY(8px);
 	}
 	to {
 		opacity: 1;
@@ -194,7 +194,7 @@
 }
 
 .animate-fade-up {
-	animation: fade-up 0.45s ease-out both;
+	animation: fade-up 0.65s cubic-bezier(0.33, 1, 0.68, 1) both;
 }
 
 .animate-fade-in {
@@ -207,7 +207,7 @@
 
 .animate-stagger {
 	--stagger: 0;
-	--delay: 85ms;
+	--delay: 110ms;
 	animation-delay: calc(var(--stagger) * var(--delay));
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -152,6 +152,18 @@
 	.maplibregl-popup-tip {
 		@apply hidden!;
 	}
+	.maplibregl-ctrl-attrib {
+		@apply bg-background! text-muted-foreground! border-border! rounded-md! border! shadow-sm!;
+	}
+	.maplibregl-ctrl-attrib a {
+		@apply text-muted-foreground!;
+	}
+	.maplibregl-ctrl-attrib a:hover {
+		@apply text-foreground!;
+	}
+	.maplibregl-ctrl-attrib-button {
+		@apply bg-transparent! dark:invert;
+	}
 }
 
 .container {

--- a/src/lib/blocks.test.ts
+++ b/src/lib/blocks.test.ts
@@ -7,6 +7,7 @@ describe("getAllBlocks", () => {
 
 		expect(blocks.map((block) => block.name)).toEqual([
 			"analytics-map",
+			"analytics-card",
 			"choropleth",
 			"uptime-monitor",
 			"logistics-network",
@@ -24,7 +25,7 @@ describe("getAllBlocks", () => {
 		expect(blocks[0].registryDependencies).toContain("card");
 		expect(blocks[0].registryDependencies?.some((d) => d.endsWith("/r/map.json"))).toBe(true);
 
-		expect(blocks[5]).toMatchObject({
+		expect(blocks[6]).toMatchObject({
 			title: "Heatmap",
 			files: [
 				{ path: "src/lib/registry/blocks/heatmap/Page.svelte", target: "heatmap/+page.svelte" },
@@ -36,7 +37,7 @@ describe("getAllBlocks", () => {
 			categories: ["visualization", "heatmap"],
 			meta: { iframeHeight: "800px" },
 		});
-		expect(blocks[5].registryDependencies?.some((d) => d.endsWith("/r/map.json"))).toBe(true);
+		expect(blocks[6].registryDependencies?.some((d) => d.endsWith("/r/map.json"))).toBe(true);
 	});
 });
 

--- a/src/lib/components/docs/preview/examples/ClusterExample.svelte
+++ b/src/lib/components/docs/preview/examples/ClusterExample.svelte
@@ -19,8 +19,6 @@
 			data="https://maplibre.org/maplibre-gl-js/docs/assets/earthquakes.geojson"
 			clusterRadius={50}
 			clusterMaxZoom={14}
-			clusterColors={["#1d8cf8", "#6d5dfc", "#e23670"]}
-			pointColor="#3b82f6"
 			onpointclick={(feature, coordinates) => {
 				if (feature.properties) {
 					selectedPoint = {

--- a/src/lib/components/home/ArcExample.svelte
+++ b/src/lib/components/home/ArcExample.svelte
@@ -19,7 +19,7 @@
 	}));
 </script>
 
-<ExampleCard class="aspect-square" stagger={8}>
+<ExampleCard class="aspect-square" stagger={6}>
 	<Map
 		center={[-0.1276, 41.5074]}
 		zoom={1}

--- a/src/lib/components/home/FlyToExample.svelte
+++ b/src/lib/components/home/FlyToExample.svelte
@@ -26,7 +26,7 @@
 	}
 </script>
 
-<ExampleCard class="aspect-square" stagger={6}>
+<ExampleCard class="aspect-square" stagger={8}>
 	<Map
 		bind:map
 		center={active.center}

--- a/src/lib/registry/blocks/analytics-card/Page.svelte
+++ b/src/lib/registry/blocks/analytics-card/Page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import TrendingUp from "@lucide/svelte/icons/trending-up";
 	import { Map, MapGeoJSON, MapMarker, MarkerContent } from "$lib/registry/blocks/map";
-	import { Button } from "$lib/registry/ui/button/index";
 	import { totalVisitors, visitorGrowth, visitorLocations } from "./data.js";
 
 	const WORLD_GEOJSON =
@@ -26,6 +25,7 @@
 					doubleClickZoom: false,
 					pitchWithRotate: false,
 				}}
+				class="[&_.maplibregl-canvas]:cursor-default! [&_.maplibregl-canvas-container]:cursor-default!"
 				blank
 			>
 				<MapGeoJSON data={WORLD_GEOJSON} linePaint={false} />
@@ -44,25 +44,27 @@
 		</div>
 
 		<div
-			class="from-card to-card/0 pointer-events-none absolute inset-x-0 top-0 z-10 h-24 rounded-t-xl bg-linear-to-b [mask-image:linear-gradient(to_bottom,black_55%,transparent)] backdrop-blur-[2px]"
+			class="from-card via-card/85 to-card/0 pointer-events-none absolute inset-x-0 top-0 z-10 h-24 rounded-t-xl bg-linear-to-b mask-[linear-gradient(to_bottom,black_70%,transparent)] backdrop-blur-[2px]"
 			aria-hidden="true"
 		></div>
 
 		<div class="relative z-20 flex items-start justify-between gap-3 p-4">
 			<div>
 				<h2 class="text-foreground text-lg font-medium tracking-tight">Analytics</h2>
-				<div class="mt-1.5 flex items-center gap-2">
-					<p class="text-muted-foreground text-xs font-medium">
-						<span class="tabular-nums">{totalVisitors}</span> visitors
-					</p>
-					<span class="inline-flex items-center gap-0.5 text-xs font-medium">
-						<TrendingUp class="size-2.5" />
-						{visitorGrowth}
-					</span>
-				</div>
+				<p class="text-muted-foreground mt-1 text-xs font-medium">Last 30 days</p>
 			</div>
 
-			<Button variant="outline" size="xs" class="h-7 px-2.5">View Analytics</Button>
+			<div class="text-right">
+				<p class="text-foreground text-lg font-medium tracking-tight tabular-nums">
+					{totalVisitors}
+				</p>
+				<span
+					class="text-muted-foreground mt-1 inline-flex items-center gap-0.5 text-xs font-medium"
+				>
+					<TrendingUp class="size-2.5" />
+					{visitorGrowth} visitors
+				</span>
+			</div>
 		</div>
 	</div>
 </div>

--- a/src/lib/registry/blocks/analytics-card/Page.svelte
+++ b/src/lib/registry/blocks/analytics-card/Page.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import TrendingUp from "@lucide/svelte/icons/trending-up";
+	import { Map, MapGeoJSON, MapMarker, MarkerContent } from "$lib/registry/blocks/map";
+	import { Button } from "$lib/registry/ui/button/index";
+	import { totalVisitors, visitorGrowth, visitorLocations } from "./data.js";
+
+	const WORLD_GEOJSON =
+		"https://cdn.jsdelivr.net/gh/nvkelso/natural-earth-vector@v5.1.2/geojson/ne_110m_admin_0_countries.geojson";
+
+	function bubbleSize(visitors: number) {
+		return Math.round(10 + Math.sqrt(visitors) * 2.2);
+	}
+</script>
+
+<div class="flex min-h-screen items-center justify-center p-8">
+	<div
+		class="bg-card relative aspect-[16/10] w-full max-w-md overflow-hidden rounded-xl border shadow-sm"
+	>
+		<div class="absolute inset-0">
+			<Map
+				center={[1, 30]}
+				options={{
+					scrollZoom: false,
+					dragRotate: false,
+					dragPan: false,
+					doubleClickZoom: false,
+					pitchWithRotate: false,
+				}}
+				blank
+			>
+				<MapGeoJSON data={WORLD_GEOJSON} linePaint={false} />
+				{#each visitorLocations as location (location.city)}
+					<MapMarker longitude={location.lng} latitude={location.lat}>
+						<MarkerContent class="cursor-default">
+							<span
+								class="bg-chart-2/80 block rounded-full"
+								style:width={`${bubbleSize(location.visitors)}px`}
+								style:height={`${bubbleSize(location.visitors)}px`}
+							></span>
+						</MarkerContent>
+					</MapMarker>
+				{/each}
+			</Map>
+		</div>
+
+		<div
+			class="from-card to-card/0 pointer-events-none absolute inset-x-0 top-0 z-10 h-24 rounded-t-xl bg-linear-to-b [mask-image:linear-gradient(to_bottom,black_55%,transparent)] backdrop-blur-[2px]"
+			aria-hidden="true"
+		></div>
+
+		<div class="relative z-20 flex items-start justify-between gap-3 p-4">
+			<div>
+				<h2 class="text-foreground text-lg font-medium tracking-tight">Analytics</h2>
+				<div class="mt-1.5 flex items-center gap-2">
+					<p class="text-muted-foreground text-xs font-medium">
+						<span class="tabular-nums">{totalVisitors}</span> visitors
+					</p>
+					<span class="inline-flex items-center gap-0.5 text-xs font-medium">
+						<TrendingUp class="size-2.5" />
+						{visitorGrowth}
+					</span>
+				</div>
+			</div>
+
+			<Button variant="outline" size="xs" class="h-7 px-2.5">View Analytics</Button>
+		</div>
+	</div>
+</div>

--- a/src/lib/registry/blocks/analytics-card/data.ts
+++ b/src/lib/registry/blocks/analytics-card/data.ts
@@ -1,0 +1,26 @@
+export interface VisitorLocation {
+	city: string;
+	lng: number;
+	lat: number;
+	visitors: number;
+}
+
+export const totalVisitors = "418.2K";
+export const visitorGrowth = "+10%";
+
+export const visitorLocations: VisitorLocation[] = [
+	{ city: "San Francisco", lng: -122.4194, lat: 37.7749, visitors: 62 },
+	{ city: "New York", lng: -74.006, lat: 40.7128, visitors: 58 },
+	{ city: "Mexico City", lng: -99.1332, lat: 19.4326, visitors: 22 },
+	{ city: "Sao Paulo", lng: -46.6333, lat: -23.5505, visitors: 30 },
+	{ city: "London", lng: -0.1276, lat: 51.5074, visitors: 48 },
+	{ city: "Berlin", lng: 13.405, lat: 52.52, visitors: 28 },
+	{ city: "Madrid", lng: -3.7038, lat: 40.4168, visitors: 18 },
+	{ city: "Lagos", lng: 3.3792, lat: 6.5244, visitors: 16 },
+	{ city: "Dubai", lng: 55.2708, lat: 25.2048, visitors: 24 },
+	{ city: "Mumbai", lng: 72.8777, lat: 19.076, visitors: 40 },
+	{ city: "Singapore", lng: 103.8198, lat: 1.3521, visitors: 21 },
+	{ city: "Tokyo", lng: 139.6917, lat: 35.6895, visitors: 38 },
+	{ city: "Seoul", lng: 126.978, lat: 37.5665, visitors: 26 },
+	{ city: "Sydney", lng: 151.2093, lat: -33.8688, visitors: 17 },
+];

--- a/src/lib/registry/blocks/map/Map.svelte
+++ b/src/lib/registry/blocks/map/Map.svelte
@@ -17,11 +17,15 @@
 		],
 	};
 
-	// Check document class for theme (works with next-themes, etc.)
+	// Check the document for an explicit theme (works with next-themes, etc.).
+	// Covers both `class` and `data-theme` attributes.
 	function getDocumentTheme(): "light" | "dark" | null {
 		if (typeof document === "undefined") return null;
-		if (document.documentElement.classList.contains("dark")) return "dark";
-		if (document.documentElement.classList.contains("light")) return "light";
+		const root = document.documentElement;
+		if (root.classList.contains("dark")) return "dark";
+		if (root.classList.contains("light")) return "light";
+		const dataTheme = root.dataset.theme;
+		if (dataTheme === "dark" || dataTheme === "light") return dataTheme;
 		return null;
 	}
 
@@ -116,10 +120,11 @@
 	let isLoaded = $state(false);
 	let isStyleLoaded = $state(false);
 	let isInteracting = $state(false);
-	let hasInitiallyLoaded = $state(false);
 	let initialStyleApplied = false;
 	let initialCenterZoomApplied = false;
-	let styleTimeoutId: ReturnType<typeof setTimeout> | null = null;
+	let pendingStyle = $state<MapStyleOption | null>(null);
+	let styleSwapInFlight = false;
+	let appliedStyleKey: string | null = null;
 	let internalUpdate = false;
 
 	const isControlled = $derived(viewport !== undefined && onviewportchange !== undefined);
@@ -146,6 +151,9 @@
 	const resolvedTheme = $derived(resolveMapTheme({ explicitTheme, ambientTheme: tailwindTheme }));
 
 	const currentStyle = $derived(resolvedTheme === "light" ? mapStyles.light : mapStyles.dark);
+	const currentStyleKey = $derived(
+		typeof currentStyle === "string" ? currentStyle : (JSON.stringify(currentStyle) ?? "")
+	);
 
 	const isReady = $derived(isMounted && isLoaded && isStyleLoaded);
 
@@ -155,13 +163,6 @@
 		isStyleReady: () => isReady,
 		resolvedTheme: () => resolvedTheme,
 	});
-
-	function clearStyleTimeout() {
-		if (styleTimeoutId) {
-			clearTimeout(styleTimeoutId);
-			styleTimeoutId = null;
-		}
-	}
 
 	onMount(() => {
 		isMounted = true;
@@ -183,7 +184,7 @@
 			observer = new MutationObserver(updateTheme);
 			observer.observe(document.documentElement, {
 				attributes: true,
-				attributeFilter: ["class"],
+				attributeFilter: ["class", "data-theme"],
 			});
 
 			// Also watch for system preference changes
@@ -211,25 +212,13 @@
 			pitch: viewport?.pitch ?? 0,
 			...options,
 		});
+		appliedStyleKey = currentStyleKey;
 
-		const styleDataHandler = () => {
-			clearStyleTimeout();
-			// Delay to ensure style is fully processed before allowing layer operations
-			// This is a workaround to avoid race conditions with the style loading
-			// else we have to force update every layer on setStyle change
-			styleTimeoutId = setTimeout(() => {
-				isStyleLoaded = true;
-				if (!initialStyleApplied) {
-					initialStyleApplied = true;
-				}
-				if (!hasInitiallyLoaded) {
-					hasInitiallyLoaded = true;
-				}
-				if (projection) {
-					mapInstance.setProjection(projection);
-				}
-				onstyleloaded?.();
-			}, 100);
+		const styleLoadHandler = () => {
+			styleSwapInFlight = false;
+			isStyleLoaded = true;
+			initialStyleApplied = true;
+			onstyleloaded?.();
 		};
 
 		const loadHandler = () => {
@@ -243,7 +232,7 @@
 		};
 
 		mapInstance.on("load", loadHandler);
-		mapInstance.on("styledata", styleDataHandler);
+		mapInstance.on("style.load", styleLoadHandler);
 		mapInstance.on("move", handleMove);
 
 		mapInstance.on("dragstart", () => (isInteracting = true));
@@ -262,9 +251,8 @@
 			if (mediaQuery && handleSystemChange) {
 				mediaQuery.removeEventListener("change", handleSystemChange);
 			}
-			clearStyleTimeout();
 			mapInstance.off("load", loadHandler);
-			mapInstance.off("styledata", styleDataHandler);
+			mapInstance.off("style.load", styleLoadHandler);
 			mapInstance.off("move", handleMove);
 			mapInstance.remove();
 			map = null;
@@ -305,33 +293,41 @@
 
 	$effect(() => {
 		const style = currentStyle;
+		const styleKey = currentStyleKey;
 
-		if (!map || !initialStyleApplied) {
+		if (!map || !initialStyleApplied || appliedStyleKey === styleKey) {
 			return;
 		}
 
-		untrack(() => {
-			const currCenter = map!.getCenter();
-			const currZoom = map!.getZoom();
-			const currBearing = map!.getBearing();
-			const currPitch = map!.getPitch();
+		appliedStyleKey = styleKey;
+		isStyleLoaded = false;
+		pendingStyle = style;
+	});
 
-			isStyleLoaded = false;
-			map!.setStyle(style, { diff: true });
+	$effect(() => {
+		const style = pendingStyle;
+		if (!map || !style) return;
 
-			map!.once("styledata", () => {
-				map!.jumpTo({
-					center: currCenter,
-					zoom: currZoom,
-					bearing: currBearing,
-					pitch: currPitch,
-				});
+		pendingStyle = null;
+		const currCenter = map.getCenter();
+		const currZoom = map.getZoom();
+		const currBearing = map.getBearing();
+		const currPitch = map.getPitch();
+
+		styleSwapInFlight = true;
+		map.setStyle(style, { diff: false });
+		map.once("style.load", () => {
+			map?.jumpTo({
+				center: currCenter,
+				zoom: currZoom,
+				bearing: currBearing,
+				pitch: currPitch,
 			});
 		});
 	});
 
 	$effect(() => {
-		if (!map || !isReady || !projection) {
+		if (!map || !isReady || !projection || styleSwapInFlight) {
 			return;
 		}
 
@@ -355,7 +351,6 @@
 	});
 
 	onDestroy(() => {
-		clearStyleTimeout();
 		isLoaded = false;
 		isStyleLoaded = false;
 	});

--- a/src/lib/registry/blocks/map/Map.svelte
+++ b/src/lib/registry/blocks/map/Map.svelte
@@ -3,6 +3,7 @@
 	import MapLibreGL from "maplibre-gl";
 	import "maplibre-gl/dist/maplibre-gl.css";
 	import { browser } from "$app/environment";
+	import { cn } from "$lib/utils.js";
 	import { resolveMapTheme } from "./theme";
 
 	const blankMapStyle: MapLibreGL.StyleSpecification = {
@@ -53,6 +54,7 @@
 
 	interface Props {
 		children?: import("svelte").Snippet;
+		class?: string;
 		styles?: {
 			light?: MapStyleOption;
 			dark?: MapStyleOption;
@@ -101,6 +103,7 @@
 
 	let {
 		children,
+		class: className,
 		styles,
 		blank = false,
 		theme: explicitTheme,
@@ -356,7 +359,7 @@
 	});
 </script>
 
-<div bind:this={mapContainer} class="relative h-full w-full">
+<div bind:this={mapContainer} class={cn("relative h-full w-full", className)}>
 	{#if !isLoaded || loading}
 		<div
 			class="bg-background/50 absolute inset-0 z-10 flex items-center justify-center backdrop-blur-xs"

--- a/src/lib/registry/blocks/map/MapClusterLayer.svelte
+++ b/src/lib/registry/blocks/map/MapClusterLayer.svelte
@@ -10,7 +10,7 @@
 		clusterMaxZoom?: number;
 		/** Radius of each cluster when clustering points in pixels (default: 50) */
 		clusterRadius?: number;
-		/** Colors for cluster circles: [small, medium, large] based on point count (default: ["#22c55e", "#eab308", "#ef4444"]) */
+		/** Colors for cluster circles: [small, medium, large] based on point count (default: ["#3b82f6", "#1d4ed8", "#1e3a8a"]) */
 		clusterColors?: [string, string, string];
 		/** Point count thresholds for color/size steps: [medium, large] (default: [100, 750]) */
 		clusterThresholds?: [number, number];
@@ -25,7 +25,7 @@
 		onclusterclick?: (clusterId: number, coordinates: [number, number], pointCount: number) => void;
 	}
 
-	const DEFAULT_CLUSTER_COLORS: [string, string, string] = ["#22c55e", "#eab308", "#ef4444"];
+	const DEFAULT_CLUSTER_COLORS: [string, string, string] = ["#3b82f6", "#1d4ed8", "#1e3a8a"];
 	const DEFAULT_CLUSTER_THRESHOLDS: [number, number] = [100, 750];
 
 	let {
@@ -97,7 +97,7 @@
 					initialClusterThresholds[1],
 					40,
 				],
-				"circle-stroke-width": 1,
+				"circle-stroke-width": 0.75,
 				"circle-stroke-color": "#fff",
 				"circle-opacity": 0.85,
 			},
@@ -111,7 +111,7 @@
 			filter: ["has", "point_count"],
 			layout: {
 				"text-field": "{point_count_abbreviated}",
-				"text-font": ["Open Sans"],
+				"text-font": ["Open Sans Semibold"],
 				"text-size": 12,
 			},
 			paint: {

--- a/src/lib/registry/blocks/map/MapControls.svelte
+++ b/src/lib/registry/blocks/map/MapControls.svelte
@@ -85,30 +85,30 @@
 	function handleLocate() {
 		const map = mapCtx.getMap();
 		if (!map) return;
+		if (!("geolocation" in navigator)) return;
 
 		waitingForLocation = true;
 
-		if ("geolocation" in navigator) {
-			navigator.geolocation.getCurrentPosition(
-				(position) => {
-					const coords = {
-						longitude: position.coords.longitude,
-						latitude: position.coords.latitude,
-					};
-					map.flyTo({
-						center: [coords.longitude, coords.latitude],
-						zoom: 14,
-						duration: 1500,
-					});
-					onlocate?.(coords);
-					waitingForLocation = false;
-				},
-				(error) => {
-					console.error("Error getting location:", error);
-					waitingForLocation = false;
-				}
-			);
-		}
+		navigator.geolocation.getCurrentPosition(
+			(position) => {
+				const coords = {
+					longitude: position.coords.longitude,
+					latitude: position.coords.latitude,
+				};
+				map.flyTo({
+					center: [coords.longitude, coords.latitude],
+					zoom: 14,
+					duration: 1500,
+				});
+				onlocate?.(coords);
+				waitingForLocation = false;
+			},
+			(error) => {
+				console.error("Error getting location:", error);
+				waitingForLocation = false;
+			},
+			{ timeout: 10000 }
+		);
 	}
 
 	function handleFullscreen() {
@@ -134,7 +134,7 @@
 					onclick={handleZoomIn}
 					aria-label="Zoom in"
 					type="button"
-					class="hover:bg-accent dark:hover:bg-accent/40 focus-visible:ring-ring flex size-8 items-center justify-center transition-all first:rounded-t-md last:rounded-b-md focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50"
+					class="hover:bg-accent dark:hover:bg-accent/40 focus-visible:ring-ring flex size-8 items-center justify-center transition-colors first:rounded-t-md last:rounded-b-md focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50"
 				>
 					<Plus class="size-4" />
 				</button>
@@ -142,7 +142,7 @@
 					onclick={handleZoomOut}
 					aria-label="Zoom out"
 					type="button"
-					class="hover:bg-accent dark:hover:bg-accent/40 focus-visible:ring-ring flex size-8 items-center justify-center transition-all first:rounded-t-md last:rounded-b-md focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50"
+					class="hover:bg-accent dark:hover:bg-accent/40 focus-visible:ring-ring flex size-8 items-center justify-center transition-colors first:rounded-t-md last:rounded-b-md focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50"
 				>
 					<Minus class="size-4" />
 				</button>
@@ -157,12 +157,12 @@
 					onclick={handleResetBearing}
 					aria-label="Reset bearing to north"
 					type="button"
-					class="hover:bg-accent dark:hover:bg-accent/40 focus-visible:ring-ring flex size-8 items-center justify-center transition-all focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50"
+					class="hover:bg-accent dark:hover:bg-accent/40 focus-visible:ring-ring flex size-8 items-center justify-center transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50"
 				>
 					<svg
 						bind:this={compassElement}
 						viewBox="0 0 24 24"
-						class="size-5 transition-transform duration-200"
+						class="size-5"
 						style="transform-style: preserve-3d;"
 					>
 						<path d="M12 2L16 12H12V2Z" class="fill-red-500" />
@@ -182,7 +182,7 @@
 					onclick={handleLocate}
 					aria-label="Find my location"
 					type="button"
-					class="hover:bg-accent dark:hover:bg-accent/40 focus-visible:ring-ring flex size-8 items-center justify-center transition-all first:rounded-t-md last:rounded-b-md focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50"
+					class="hover:bg-accent dark:hover:bg-accent/40 focus-visible:ring-ring flex size-8 items-center justify-center transition-colors first:rounded-t-md last:rounded-b-md focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50"
 					disabled={waitingForLocation}
 				>
 					{#if waitingForLocation}
@@ -202,7 +202,7 @@
 					onclick={handleFullscreen}
 					aria-label="Toggle fullscreen"
 					type="button"
-					class="hover:bg-accent dark:hover:bg-accent/40 focus-visible:ring-ring flex size-8 items-center justify-center transition-all first:rounded-t-md last:rounded-b-md focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50"
+					class="hover:bg-accent dark:hover:bg-accent/40 focus-visible:ring-ring flex size-8 items-center justify-center transition-colors first:rounded-t-md last:rounded-b-md focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50"
 				>
 					<Maximize class="size-4" />
 				</button>

--- a/src/routes/docs/api-reference/+page.svelte
+++ b/src/routes/docs/api-reference/+page.svelte
@@ -629,7 +629,7 @@
 				{
 					name: "clusterColors",
 					type: "[string, string, string]",
-					default: '["#51bbd6", "#f1f075", "#f28cb1"]',
+					default: '["#3b82f6", "#1d4ed8", "#1e3a8a"]',
 					description: "Colors for cluster circles: [small, medium, large] based on point count.",
 				},
 				{

--- a/src/routes/view/[name]/+page.ts
+++ b/src/routes/view/[name]/+page.ts
@@ -3,6 +3,7 @@ import type { PageLoad } from "./$types";
 
 const blockComponents: Record<string, () => Promise<{ default: unknown }>> = {
 	"analytics-map": () => import("$lib/registry/blocks/analytics-map/Page.svelte"),
+	"analytics-card": () => import("$lib/registry/blocks/analytics-card/Page.svelte"),
 	choropleth: () => import("$lib/registry/blocks/choropleth/Page.svelte"),
 	heatmap: () => import("$lib/registry/blocks/heatmap/Page.svelte"),
 	"delivery-tracker": () => import("$lib/registry/blocks/delivery-tracker/Page.svelte"),


### PR DESCRIPTION
## Summary

Ports the latest MapCN changes onto the Svelte implementation across the full branch diff.

### Map runtime and controls

- Replaced debounced `styledata` handling with deterministic `style.load` handling.
- Staged theme/style swaps so map layers and projections reapply safely after a style change.
- Preserved the viewport across style swaps and avoided projection updates while a swap is in flight.
- Stabilized equivalent style values to avoid unnecessary reloads.
- Added `data-theme` support alongside class-based theme detection.
- Added a timeout and unavailable-geolocation guard for the locate control.
- Switched control hover transitions to color-only transitions and simplified compass styling.
- Added themed MapLibre attribution control styling.

### Registry and examples

- Added the new `analytics-card` registry block with visitor metrics, world GeoJSON, and proportional location markers.
- Added the analytics-card block route and registry metadata.
- Regenerated registry output through the normal build process.
- Updated cluster defaults to a blue palette, lighter cluster outlines, and semibold cluster labels.
- Updated the cluster example and API reference to use the new defaults.
- Adjusted homepage Arc/FlyTo stagger ordering and animation timing.

### Validation

- `pnpm check`
- `pnpm lint`
- `pnpm test` — 70 tests passing
- `pnpm peers check`
- `pnpm build`

The production build completes successfully.
