### PR TITLE
Port MapCN updates after July 20

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -187,7 +187,7 @@
 			"title": "Analytics Card",
 			"description": "Compact analytics card with a headline metric over a world map.",
 			"dependencies": ["maplibre-gl"],
-			"registryDependencies": ["https://mapcn-svelte.dev/r/map.json"],
+			"registryDependencies": ["https://mapcn-svelte.dev/r/map.json", "card", "badge"],
 			"files": [
 				{
 					"path": "src/lib/registry/blocks/analytics-card/Page.svelte",

--- a/src/app.css
+++ b/src/app.css
@@ -206,7 +206,7 @@
 }
 
 .animate-fade-up {
-	animation: fade-up 0.65s cubic-bezier(0.33, 1, 0.68, 1) both;
+	animation: fade-up 0.6s both;
 }
 
 .animate-fade-in {
@@ -219,7 +219,7 @@
 
 .animate-stagger {
 	--stagger: 0;
-	--delay: 110ms;
+	--delay: 0.12s;
 	animation-delay: calc(var(--stagger) * var(--delay));
 }
 

--- a/src/lib/blocks.test.ts
+++ b/src/lib/blocks.test.ts
@@ -7,13 +7,13 @@ describe("getAllBlocks", () => {
 
 		expect(blocks.map((block) => block.name)).toEqual([
 			"analytics-map",
-			"analytics-card",
 			"choropleth",
+			"analytics-card",
+			"delivery-tracker",
 			"uptime-monitor",
+			"heatmap",
 			"logistics-network",
 			"store-locator",
-			"heatmap",
-			"delivery-tracker",
 		]);
 		expect(blocks.every((block) => block.type === "registry:block")).toBe(true);
 
@@ -25,7 +25,7 @@ describe("getAllBlocks", () => {
 		expect(blocks[0].registryDependencies).toContain("card");
 		expect(blocks[0].registryDependencies?.some((d) => d.endsWith("/r/map.json"))).toBe(true);
 
-		expect(blocks[6]).toMatchObject({
+		expect(blocks[5]).toMatchObject({
 			title: "Heatmap",
 			files: [
 				{ path: "src/lib/registry/blocks/heatmap/Page.svelte", target: "heatmap/+page.svelte" },
@@ -37,7 +37,7 @@ describe("getAllBlocks", () => {
 			categories: ["visualization", "heatmap"],
 			meta: { iframeHeight: "800px" },
 		});
-		expect(blocks[6].registryDependencies?.some((d) => d.endsWith("/r/map.json"))).toBe(true);
+		expect(blocks[5].registryDependencies?.some((d) => d.endsWith("/r/map.json"))).toBe(true);
 	});
 });
 

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -22,10 +22,26 @@ export interface FileTree {
 }
 
 const typedRegistry = registry as RegistrySchema;
+const upstreamBlockOrder = [
+	"analytics-map",
+	"choropleth",
+	"analytics-card",
+	"delivery-tracker",
+	"uptime-monitor",
+	"heatmap",
+	"logistics-network",
+	"store-locator",
+];
+const upstreamBlockRank = new Map(upstreamBlockOrder.map((name, index) => [name, index]));
 
 export function getAllBlocks(): RegistryBlockItem[] {
 	return typedRegistry.items
 		.filter((item) => item.type === "registry:block")
+		.toSorted(
+			(a, b) =>
+				(upstreamBlockRank.get(a.name) ?? Number.POSITIVE_INFINITY) -
+				(upstreamBlockRank.get(b.name) ?? Number.POSITIVE_INFINITY)
+		)
 		.map((item) => ({
 			name: item.name,
 			type: item.type,

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -24,11 +24,6 @@
 			{ label: "Tailwind CSS", href: "https://tailwindcss.com/", external: true },
 		],
 	};
-
-	const socialLinks = [
-		{ label: "GitHub", href: "https://github.com/AnmolSaini16/mapcn" },
-		{ label: "X", href: "https://x.com/anmold_s" },
-	];
 </script>
 
 <footer class={cn("bg-muted/30 mt-24 border-t md:mt-40", className)}>
@@ -40,29 +35,19 @@
 					Free & open-source, ready-to-use, customizable map components for Svelte.
 				</p>
 				<div class="mt-4 flex items-center gap-4">
-					{#each socialLinks as social (social.href)}
-						<a
-							href={social.href}
-							target="_blank"
-							rel="noopener noreferrer"
-							aria-label={social.label}
-							class="text-muted-foreground hover:text-foreground transition-colors"
-						>
-							{#if social.label === "GitHub"}
-								<svg viewBox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true">
-									<path
-										d="M12 .7a11.3 11.3 0 0 0-3.6 22c.6.1.8-.2.8-.5v-2.2c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.4-1.3-5.4-5.6 0-1.2.4-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.1 1.2a10.8 10.8 0 0 1 5.7 0c2.2-1.5 3.1-1.2 3.1-1.2.6 1.6.2 2.8.1 3.1.8.8 1.2 1.9 1.2 3.1 0 4.3-2.8 5.3-5.4 5.6.4.4.8 1.1.8 2.2v3.2c0 .3.2.7.8.5A11.3 11.3 0 0 0 12 .7Z"
-									/>
-								</svg>
-							{:else}
-								<svg viewBox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true">
-									<path
-										d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
-									/>
-								</svg>
-							{/if}
-						</a>
-					{/each}
+					<a
+						href="https://github.com/MariusLang/mapcn-svelte"
+						target="_blank"
+						rel="noopener noreferrer"
+						aria-label="GitHub"
+						class="text-muted-foreground hover:text-foreground transition-colors"
+					>
+						<svg viewBox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true">
+							<path
+								d="M12 .7a11.3 11.3 0 0 0-3.6 22c.6.1.8-.2.8-.5v-2.2c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.4-1.3-5.4-5.6 0-1.2.4-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.1 1.2a10.8 10.8 0 0 1 5.7 0c2.2-1.5 3.1-1.2 3.1-1.2.6 1.6.2 2.8.1 3.1.8.8 1.2 1.9 1.2 3.1 0 4.3-2.8 5.3-5.4 5.6.4.4.8 1.1.8 2.2v3.2c0 .3.2.7.8.5A11.3 11.3 0 0 0 12 .7Z"
+							/>
+						</svg>
+					</a>
 				</div>
 			</div>
 
@@ -117,12 +102,6 @@
 					{/each}
 				</ul>
 			</div>
-		</div>
-
-		<div class="mt-12 border-t pt-6">
-			<p class="text-muted-foreground text-xs">
-				© {new Date().getFullYear()} mapcn. All rights reserved.
-			</p>
 		</div>
 	</div>
 </footer>

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -24,9 +24,14 @@
 			{ label: "Tailwind CSS", href: "https://tailwindcss.com/", external: true },
 		],
 	};
+
+	const socialLinks = [
+		{ label: "GitHub", href: "https://github.com/AnmolSaini16/mapcn" },
+		{ label: "X", href: "https://x.com/anmold_s" },
+	];
 </script>
 
-<footer class={cn("mt-30 border-t", className)}>
+<footer class={cn("bg-muted/30 mt-24 border-t md:mt-40", className)}>
 	<div class="container py-12 md:py-16">
 		<div class="grid grid-cols-2 gap-8 md:grid-cols-5">
 			<div class="col-span-2 md:col-span-2">
@@ -34,26 +39,31 @@
 				<p class="text-muted-foreground mt-2 max-w-xs text-sm leading-relaxed">
 					Free & open-source, ready-to-use, customizable map components for Svelte.
 				</p>
-				<p class="text-muted-foreground mt-3 text-sm">
-					Built by
-					<a
-						href="https://github.com/AnmolSaini16"
-						target="_blank"
-						rel="noopener noreferrer"
-						class="text-muted-foreground hover:text-foreground text-sm font-medium transition-colors"
-					>
-						@anmol
-					</a>
-					· Ported by
-					<a
-						href="https://github.com/MariusLang"
-						target="_blank"
-						rel="noopener noreferrer"
-						class="text-muted-foreground hover:text-foreground text-sm font-medium transition-colors"
-					>
-						@marius
-					</a>
-				</p>
+				<div class="mt-4 flex items-center gap-4">
+					{#each socialLinks as social (social.href)}
+						<a
+							href={social.href}
+							target="_blank"
+							rel="noopener noreferrer"
+							aria-label={social.label}
+							class="text-muted-foreground hover:text-foreground transition-colors"
+						>
+							{#if social.label === "GitHub"}
+								<svg viewBox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true">
+									<path
+										d="M12 .7a11.3 11.3 0 0 0-3.6 22c.6.1.8-.2.8-.5v-2.2c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.4-1.3-5.4-5.6 0-1.2.4-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.1 1.2a10.8 10.8 0 0 1 5.7 0c2.2-1.5 3.1-1.2 3.1-1.2.6 1.6.2 2.8.1 3.1.8.8 1.2 1.9 1.2 3.1 0 4.3-2.8 5.3-5.4 5.6.4.4.8 1.1.8 2.2v3.2c0 .3.2.7.8.5A11.3 11.3 0 0 0 12 .7Z"
+									/>
+								</svg>
+							{:else}
+								<svg viewBox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true">
+									<path
+										d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+									/>
+								</svg>
+							{/if}
+						</a>
+					{/each}
+				</div>
 			</div>
 
 			<div>
@@ -107,6 +117,12 @@
 					{/each}
 				</ul>
 			</div>
+		</div>
+
+		<div class="mt-12 border-t pt-6">
+			<p class="text-muted-foreground text-xs">
+				© {new Date().getFullYear()} mapcn. All rights reserved.
+			</p>
 		</div>
 	</div>
 </footer>

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -2,9 +2,7 @@
 	import { onMount } from "svelte";
 	import { theme } from "$lib/theme";
 	import { Button } from "$lib/registry/ui/button/index";
-	import { Kbd } from "$lib/registry/ui/kbd/index";
 	import { Skeleton } from "$lib/registry/ui/skeleton";
-	import * as Tooltip from "$lib/registry/ui/tooltip/index";
 	import Moon from "@lucide/svelte/icons/moon";
 	import Sun from "@lucide/svelte/icons/sun";
 
@@ -48,19 +46,12 @@
 {#if !mounted}
 	<Skeleton class="size-8" />
 {:else}
-	<Tooltip.Root>
-		<Tooltip.Trigger>
-			<Button onclick={toggleTheme} variant="ghost" aria-label="Toggle theme" size="icon-sm">
-				{#if currentTheme === "dark"}
-					<Moon />
-				{:else}
-					<Sun />
-				{/if}
-				<span class="sr-only">Toggle theme</span>
-			</Button>
-		</Tooltip.Trigger>
-		<Tooltip.Content class="flex items-center gap-2 pr-1">
-			Toggle Theme <Kbd>T</Kbd>
-		</Tooltip.Content>
-	</Tooltip.Root>
+	<Button onclick={toggleTheme} variant="ghost" aria-label="Toggle theme" size="icon-sm">
+		{#if currentTheme === "dark"}
+			<Moon />
+		{:else}
+			<Sun />
+		{/if}
+		<span class="sr-only">Toggle theme</span>
+	</Button>
 {/if}

--- a/src/lib/components/blocks/IframePreview.svelte
+++ b/src/lib/components/blocks/IframePreview.svelte
@@ -1,12 +1,31 @@
 <script lang="ts">
+	import { onMount } from "svelte";
+	import { theme } from "$lib/theme";
+
 	interface Props {
 		src: string;
 		title: string;
 	}
 
 	const { src, title }: Props = $props();
+	let iframe: HTMLIFrameElement;
+	let currentTheme: "light" | "dark" = "light";
+
+	function syncTheme() {
+		iframe?.contentWindow?.postMessage(
+			{ type: "mapcn:theme", theme: currentTheme },
+			window.location.origin
+		);
+	}
+
+	onMount(() => {
+		return theme.subscribe((value) => {
+			currentTheme = value;
+			syncTheme();
+		});
+	});
 </script>
 
 <div class="relative h-(--block-preview-height) w-full overflow-hidden rounded-xl border">
-	<iframe {src} {title} class="size-full border-0"></iframe>
+	<iframe bind:this={iframe} {src} {title} class="size-full border-0" onload={syncTheme}></iframe>
 </div>

--- a/src/lib/registry/blocks/analytics-card/Page.svelte
+++ b/src/lib/registry/blocks/analytics-card/Page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import TrendingUp from "@lucide/svelte/icons/trending-up";
 	import { Map, MapGeoJSON, MapMarker, MarkerContent } from "$lib/registry/blocks/map";
+	import { Badge } from "$lib/registry/ui/badge";
+	import * as Card from "$lib/registry/ui/card";
 	import { totalVisitors, visitorGrowth, visitorLocations } from "./data.js";
 
 	const WORLD_GEOJSON =
@@ -12,9 +14,7 @@
 </script>
 
 <div class="flex min-h-screen items-center justify-center p-8">
-	<div
-		class="bg-card relative aspect-[16/10] w-full max-w-md overflow-hidden rounded-xl border shadow-sm"
-	>
+	<Card.Root class="relative aspect-[16/10] w-full max-w-md overflow-hidden py-0">
 		<div class="absolute inset-0">
 			<Map
 				center={[1, 30]}
@@ -43,28 +43,18 @@
 			</Map>
 		</div>
 
-		<div
-			class="from-card via-card/85 to-card/0 pointer-events-none absolute inset-x-0 top-0 z-10 h-24 rounded-t-xl bg-linear-to-b mask-[linear-gradient(to_bottom,black_70%,transparent)] backdrop-blur-[2px]"
-			aria-hidden="true"
-		></div>
+		<Card.Header
+			class="from-card via-card/85 to-card/0 relative z-10 gap-1 rounded-t-[inherit] bg-linear-to-b pt-4 pb-10 mask-[linear-gradient(to_bottom,black_calc(100%_-_2.5rem),transparent)] backdrop-blur-[2px]"
+		>
+			<Card.Description>Visitors</Card.Description>
+			<Card.Title class="text-lg tabular-nums">{totalVisitors}</Card.Title>
 
-		<div class="relative z-20 flex items-start justify-between gap-3 p-4">
-			<div>
-				<h2 class="text-foreground text-lg font-medium tracking-tight">Analytics</h2>
-				<p class="text-muted-foreground mt-1 text-xs font-medium">Last 30 days</p>
-			</div>
-
-			<div class="text-right">
-				<p class="text-foreground text-lg font-medium tracking-tight tabular-nums">
-					{totalVisitors}
-				</p>
-				<span
-					class="text-muted-foreground mt-1 inline-flex items-center gap-0.5 text-xs font-medium"
-				>
-					<TrendingUp class="size-2.5" />
-					{visitorGrowth} visitors
-				</span>
-			</div>
-		</div>
-	</div>
+			<Card.Action>
+				<Badge variant="outline">
+					<TrendingUp />
+					{visitorGrowth} growth
+				</Badge>
+			</Card.Action>
+		</Card.Header>
+	</Card.Root>
 </div>

--- a/src/lib/registry/blocks/analytics-card/data.ts
+++ b/src/lib/registry/blocks/analytics-card/data.ts
@@ -6,7 +6,7 @@ export interface VisitorLocation {
 }
 
 export const totalVisitors = "418.2K";
-export const visitorGrowth = "+10%";
+export const visitorGrowth = "+12%";
 
 export const visitorLocations: VisitorLocation[] = [
 	{ city: "San Francisco", lng: -122.4194, lat: 37.7749, visitors: 62 },

--- a/src/lib/registry/ui/command/command-dialog.svelte
+++ b/src/lib/registry/ui/command/command-dialog.svelte
@@ -28,7 +28,7 @@
 		<Dialog.Title>{title}</Dialog.Title>
 		<Dialog.Description>{description}</Dialog.Description>
 	</Dialog.Header>
-	<Dialog.Content class="top-[12%] translate-y-0 overflow-hidden p-0" {portalProps}>
+	<Dialog.Content class="top-[min(22vh,10rem)] translate-y-0 overflow-hidden p-0" {portalProps}>
 		<Command
 			class="**:data-[slot=command-input-wrapper]:h-12 [&_[data-command-group]]:px-2 [&_[data-command-group]:not([hidden])_~[data-command-group]]:pt-0 [&_[data-command-input-wrapper]_svg]:h-5 [&_[data-command-input-wrapper]_svg]:w-5 [&_[data-command-input]]:h-12 [&_[data-command-item]]:px-2 [&_[data-command-item]]:py-3 [&_[data-command-item]_svg]:h-5 [&_[data-command-item]_svg]:w-5"
 			{...restProps}

--- a/src/routes/view/[name]/+page.svelte
+++ b/src/routes/view/[name]/+page.svelte
@@ -1,8 +1,25 @@
 <script lang="ts">
+	import { onMount } from "svelte";
+	import { theme } from "$lib/theme";
 	import type { PageData } from "./$types";
 
 	const { data }: { data: PageData } = $props();
 	const Component = $derived(data.component as import("svelte").Component);
+
+	onMount(() => {
+		function syncTheme(event: MessageEvent) {
+			if (
+				event.origin === window.location.origin &&
+				event.data?.type === "mapcn:theme" &&
+				(event.data.theme === "light" || event.data.theme === "dark")
+			) {
+				theme.set(event.data.theme);
+			}
+		}
+
+		window.addEventListener("message", syncTheme);
+		return () => window.removeEventListener("message", syncTheme);
+	});
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary

- port upstream MapCN commits after July 20 that were not already present on `main`:
  - `cf2ecad` refactors analytics-card onto Card and Badge primitives, updates growth to 12%, and softens entrance timing
  - `50c6760` makes the analytics-card header scrim size from its content
  - `874e2c9` refreshes the footer, simplifies the theme toggle, and adjusts command-dialog placement
- restore the upstream blocks-page order: Analytics Map, Choropleth, Analytics Card, Delivery Tracker, Uptime Monitor, Heatmap, Logistics Network, Store Locator
- fix dark-mode previews by synchronizing theme changes from the blocks page into every preview iframe

## Why

The blocks page rendered its previews in separate documents. Theme changes only updated the parent document, so already-loaded previews stayed on the previous theme. Explicit theme messaging now keeps all eight previews synchronized in both directions of the light/dark toggle.

## Validation

- `pnpm build:registry`
- `pnpm check`
- `pnpm lint`
- `pnpm test` (70 passing)
- `pnpm peers check`
- `pnpm build`
- browser-backed full-page inspection of `/blocks` in light and dark mode
- confirmed all eight iframe documents receive the active theme
- confirmed block heading order matches upstream
- confirmed no browser runtime errors or framework error overlays

The production build completed successfully with the existing non-fatal offline OSRM DNS warning.
